### PR TITLE
Fix redis plugin crashes on timeouts and other errors (LOGSTASH-1475 et al.)

### DIFF
--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -5,7 +5,7 @@ require "logstash/namespace"
 
 # This input will read events from a Redis instance; it supports both Redis channels and lists.
 # The list command (BLPOP) used by Logstash is supported in Redis v1.3.1+, and
-# the channel commands used by Logstash are found in Redis v1.3.8+. 
+# the channel commands used by Logstash are found in Redis v1.3.8+.
 # While you may be able to make these Redis versions work, the best performance
 # and stability will be found in more recent stable versions.  Versions 2.6.0+
 # are recommended.
@@ -227,14 +227,11 @@ EOF
       begin
         @redis ||= connect
         self.send listener, @redis, output_queue
-      rescue Redis::CannotConnectError => e
+      rescue Redis::BaseError => e
         @logger.warn("Redis connection problem", :exception => e)
+        # Reset the redis variable to trigger reconnect
+        @redis = nil
         sleep 1
-        @redis = connect
-      rescue => e # Redis error
-        @logger.warn("Failed to get event from Redis", :name => @name,
-                     :exception => e, :backtrace => e.backtrace)
-        raise e
       end
     end # while !finished?
   end # listener_loop
@@ -252,15 +249,19 @@ EOF
 
   public
   def teardown
-    if @data_type == 'channel' and @redis
-      @redis.unsubscribe
-      @redis.quit
-      @redis = nil
+    if @redis
+      if @data_type == 'list'
+        @redis.quit
+      elsif @data_type == 'channel'
+        @redis.unsubscribe
+        @redis.quit
+      elsif @data_type == 'pattern_channel'
+        @redis.punsubscribe
+        @redis.quit
+      end
     end
-    if @data_type == 'pattern_channel' and @redis
-      @redis.punsubscribe
-      @redis.quit
-      @redis = nil
-    end
+  rescue Redis::BaseError
+  ensure
+    @redis = nil
   end
 end # class LogStash::Inputs::Redis


### PR DESCRIPTION
Relocated this from main logstash repo as I suspect the patch will be needed here instead!

Reproduce timeout crash (LOGSTASH-1475 et al.)
1. Start redis and logstash
2. Stop redis and immediately start a blackhole listener to create symptoms of a connect timeout that raises the same exception as a regular timeout (e.g. `service redis stop; nc -kl 6379 >/dev/null`)
3. Watch logstash logs. "Failed to get event from redis" appears and the plugin crashes and is restarted. This occurs on every timeout occurrence.

Fix for timeout crash:
Capture all redis related errors and not just connection errors.
Also clear redis and reconnect again - it cuts down on the EVAL errors due to batch script missing and is a proper reconnect.

Reproduce subscribe crash and stop: (noticed it while fixing above)
1. Start redis and logstash with data type channel
2. Stop redis and immediately start a blackhole listener to create symptoms of a connect timeout that raises the same exception as a regular timeout
3. Watch logstash logs. "Failed to get event from redis" appears and the plugin crashes and is restarted.
4. However, it then doesn't appear to restart properly sometimes and ends up dead

Fix for subscribe crash and stop:
Same as for timeout crash but also protect plugin teardown from crashing. It seems it calls "unsubscribe" which could throw a connection error ("quit" never will) which crashes the plugin restart process.
Also clear redis in teardown so we force a reconnect on startup - otherwise we try to use same connection and rely on redis-rb to reconnect, which is not a true "restart" and results in extra EVAL errors due to batch script missing.