### PR TITLE
Fix unrecoverable crash on server connection issues

### DIFF
--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -252,10 +252,18 @@ EOF
       if @data_type == 'list'
         @redis.quit
       elsif @data_type == 'channel'
-        @redis.unsubscribe
+        begin
+          @redis.unsubscribe
+        rescue RuntimeError => e
+          @logger.warn("Couldn't unsubscribe from redis channel", :exception => e)
+        end
         @redis.quit
       elsif @data_type == 'pattern_channel'
-        @redis.punsubscribe
+        begin
+          @redis.punsubscribe
+        rescue RuntimeError => e
+          @logger.warn("Couldn't unsubscribe from redis channel", :exception => e)
+        end
         @redis.quit
       end
     end


### PR DESCRIPTION
When the plugin loses the connection with a redis server logstash will restart it with a teardown that, when data_type is a channel, will do an unsubscribe that results in "RuntimeError: Can't unsubscribe if not subscribed."

Instead log a warning and go on quitting redis.