### PR TITLE
Proposal to unify a bit the host behaviour for redis input and redis output

### DIFF
--- a/lib/logstash/inputs/redis/common.rb
+++ b/lib/logstash/inputs/redis/common.rb
@@ -1,0 +1,20 @@
+module LogStash
+  module Inputs
+    module RedisCommon
+
+      def self.included(base)
+        # The hostname of your Redis server.
+        base.config :host, :validate => :string, :default => "127.0.0.1:6379"
+
+        # The default port to connect to.
+        base.config :port, :validate => :number, :default => 6379
+      end
+
+      private
+      def connection_host
+        host, port = @host.split(":")
+        "#{host}:#{(port.nil? ? @port : port)}"
+      end
+    end
+  end
+end

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -82,9 +82,39 @@ describe LogStash::Inputs::Redis do
       .new(cfg).add_external_redis_builder(builder)
   end
 
+
   context 'construction' do
+
     it 'registers the input' do
       expect {subject.register}.not_to raise_error
+    end
+
+    describe "default values" do
+      let(:config) do
+        cfg.merge({ "host" => "127.0.0.1"})
+      end
+
+      let(:input) { described_class.new(config) }
+
+      before(:each) do
+        input.register
+      end
+
+      it "use default port when not specified" do
+        expect(input.redis_url).to eq("redis://@127.0.0.1:6379/0")
+      end
+    end
+
+    describe "configuration options" do
+      it "raise an error with valid string host" do
+        config = cfg.merge({ "host" => "127.0.0.1:8080"})
+        expect{ described_class.new(config) }.not_to raise_error
+      end
+
+      it "raise an error with non valid hosts" do
+        config = cfg.merge({ "host" => [ "127.0.0.1:8080", "128.0.0.1:8081" ]})
+        expect{ described_class.new(config) }.to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
As the way the `logstash-output-redis` works, there are is the option to actually have a host+port defined only as `host:port`, then the port options is more a default port in case of having only defined `host`. 

This PR basically enabled this for the redis input have a similar notation as the redis output, but still only enabling connection to 1 redis instance.

Related bug: https://github.com/elastic/logstash/issues/5120
