### PR TITLE
Fixes #32 Add used redis channel to incoming events

### DIFF
--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -148,10 +148,11 @@ EOF
   end
 
   # private
-  def queue_event(msg, output_queue)
+  def queue_event(msg, output_queue, channel=nil)
     begin
       @codec.decode(msg) do |event|
         decorate(event)
+        event.set("redis_channel", channel) if !channel.nil?
         output_queue << event
       end
     rescue => e # parse or event creation error
@@ -273,7 +274,7 @@ EOF
       end
 
       on.message do |channel, message|
-        queue_event(message, output_queue)
+        queue_event(message, output_queue, channel)
       end
 
       on.unsubscribe do |channel, count|
@@ -296,7 +297,7 @@ EOF
       end
 
       on.pmessage do |pattern, channel, message|
-        queue_event(message, output_queue)
+        queue_event(message, output_queue, channel)
       end
 
       on.punsubscribe do |channel, count|

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -271,6 +271,18 @@ describe LogStash::Inputs::Redis do
 
           expect(accumulator.size).to eq(2)
         end
+        it 'events had redis_channel' do 
+          #simulate the input thread
+          rt = run_it_thread(instance)
+          #simulate the other system thread
+          publish_thread(instance.new_redis_instance, 'c').join
+          #simulate the pipeline thread
+          close_thread(instance, rt).join
+          e1 = accumulator.pop 
+          e2 = accumulator.pop
+          expect(e1.get('redis_channel')).to eq('foo')
+          expect(e2.get('redis_channel')).to eq('foo')
+        end
       end
     end
 
@@ -297,6 +309,18 @@ describe LogStash::Inputs::Redis do
           close_thread(instance, rt).join
 
           expect(accumulator.size).to eq(2)
+        end
+        it 'events had redis_channel' do 
+          #simulate the input thread
+          rt = run_it_thread(instance)
+          #simulate the other system thread
+          publish_thread(instance.new_redis_instance, 'pc').join
+          #simulate the pipeline thread
+          close_thread(instance, rt).join
+          e1 = accumulator.pop 
+          e2 = accumulator.pop
+          expect(e1.get('redis_channel')).to eq('foo')
+          expect(e2.get('redis_channel')).to eq('foo')
         end
       end
     end


### PR DESCRIPTION
Adds the redis channel used to events, useful for selecting filters and add dynamic data to events
