### PR TITLE
Add metrics support for the redis input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+ - Add metrics support to track number of events, connections, including errors (based on exception being raised).
+
 ## 3.1.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -133,6 +133,7 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
   def connect
     redis = new_redis_instance
     load_batch_script(redis) if batched? && is_list_type?
+    metric.increment(:connections)
     redis
   end # def connect
 

--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-redis'
-  s.version         = '3.1.1'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input will read events from a Redis instance"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Add metrics to track:
- # events processed.
- # connections.
- # subscribed channels, if using this feature.
- # errors happening in different situations. 

related to https://github.com/elastic/logstash/issues/5607 https://github.com/elastic/logstash/issues/5717
