### PR TITLE
lock redis gem to 3.x - 4.x requires ruby 2.2

### DIFF
--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'redis'
+  s.add_runtime_dependency "redis", "~> 3.0"
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Without a version lock, bundler will attempt to install redis gem v4.x, which requires ruby 2.2 or greater.
See https://github.com/elastic/logstash-docker/issues/50#issuecomment-328412383 for more information.