### PR TITLE
Pin redis dep to 3.x.x since 4.x requires ruby 2+ syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.5
+  - Pin 'redis' gem dependency to major version range 3.x
+
 ## 3.1.4
   - Fix some documentation issues
 

--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-redis'
-  s.version         = '3.1.4'
+  s.version         = '3.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This input will read events from a Redis instance"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'redis'
+  s.add_runtime_dependency 'redis', '~> 3'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
This is preventing bundle updates on 5.x series logstashes (using jruby 1.7.x) from working correctly.

Also, we never should have had such a loose version req. It didn't matter till recently since the redis gem was stuck on 3.x for so long.