### PR TITLE
Adding SSL Support

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -48,6 +48,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-threads>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-timeout>> |<<number,number>>|No
 |=======================================================================
@@ -116,6 +117,15 @@ Password to authenticate with. There is no authentication by default.
   * Default value is `6379`
 
 The port to connect on.
+
+[id="plugins-{type}s-{plugin}-ssl"]
+===== `ssl` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `false`
+
+Enable SSL support.
+
 
 [id="plugins-{type}s-{plugin}-threads"]
 ===== `threads` 

--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -29,6 +29,9 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
   # The port to connect on.
   config :port, :validate => :number, :default => 6379
 
+  # SSL
+  config :ssl, :validate => :boolean, :default => false
+
   # The Redis database number.
   config :db, :validate => :number, :default => 0
 
@@ -119,7 +122,8 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
       :port => @port,
       :timeout => @timeout,
       :db => @db,
-      :password => @password.nil? ? nil : @password.value
+      :password => @password.nil? ? nil : @password.value,
+      :ssl => @ssl
     }
   end
 


### PR DESCRIPTION
This pull request adds SSL support to the configuration with this option:
**ssl**: _boolean_, default false

Usage example:
```
input {
   redis {
   	host => "securehost-redis.example.org"
   	port => 6380
   	data_type => "list"
   	key => "keyname"
	ssl => true
   }
}
```

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
