### PR TITLE
Add support for Redis unix sockets

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -45,6 +45,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-data_type>> |<<string,string>>, one of `["list", "channel", "pattern_channel"]`|Yes
 | <<plugins-{type}s-{plugin}-db>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-path>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
@@ -89,8 +90,18 @@ The Redis database number.
 
   * Value type is <<string,string>>
   * Default value is `"127.0.0.1"`
+  * Path and Host are mutually exclusive - Logstash will throw an error if both are specified.
 
 The hostname of your Redis server.
+
+id="plugins-{type}s-{plugin}-path"]
+===== `path` 
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+  * Path and Host are mutually exclusive - Logstash will throw an error if both are specified.
+
+The unix socket path of your Redis server.
 
 [id="plugins-{type}s-{plugin}-key"]
 ===== `key` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,7 +59,7 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-batch_count"]
-===== `batch_count` 
+===== `batch_count`
 
   * Value type is <<number,number>>
   * Default value is `125`
@@ -67,7 +67,7 @@ input plugins.
 The number of events to return from Redis using EVAL.
 
 [id="plugins-{type}s-{plugin}-data_type"]
-===== `data_type` 
+===== `data_type`
 
   * This is a required setting.
   * Value can be any of: `list`, `channel`, `pattern_channel`
@@ -78,7 +78,7 @@ key.  If `redis\_type` is `channel`, then we will SUBSCRIBE to the key.
 If `redis\_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
 
 [id="plugins-{type}s-{plugin}-db"]
-===== `db` 
+===== `db`
 
   * Value type is <<number,number>>
   * Default value is `0`
@@ -86,25 +86,24 @@ If `redis\_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
 The Redis database number.
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * Value type is <<string,string>>
   * Default value is `"127.0.0.1"`
-  * Path and Host are mutually exclusive - Logstash will throw an error if both are specified.
 
 The hostname of your Redis server.
 
 id="plugins-{type}s-{plugin}-path"]
-===== `path` 
+===== `path`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
-  * Path and Host are mutually exclusive - Logstash will throw an error if both are specified.
+  * Path will override Host configuration if both specified.
 
 The unix socket path of your Redis server.
 
 [id="plugins-{type}s-{plugin}-key"]
-===== `key` 
+===== `key`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -113,7 +112,7 @@ The unix socket path of your Redis server.
 The name of a Redis list or channel.
 
 [id="plugins-{type}s-{plugin}-password"]
-===== `password` 
+===== `password`
 
   * Value type is <<password,password>>
   * There is no default value for this setting.
@@ -121,7 +120,7 @@ The name of a Redis list or channel.
 Password to authenticate with. There is no authentication by default.
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port` 
+===== `port`
 
   * Value type is <<number,number>>
   * Default value is `6379`
@@ -129,7 +128,7 @@ Password to authenticate with. There is no authentication by default.
 The port to connect on.
 
 [id="plugins-{type}s-{plugin}-threads"]
-===== `threads` 
+===== `threads`
 
   * Value type is <<number,number>>
   * Default value is `1`
@@ -137,7 +136,7 @@ The port to connect on.
 
 
 [id="plugins-{type}s-{plugin}-timeout"]
-===== `timeout` 
+===== `timeout`
 
   * Value type is <<number,number>>
   * Default value is `5`

--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -29,6 +29,10 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
   # The port to connect on.
   config :port, :validate => :number, :default => 6379
 
+  # The unix socket path to connect on. Will override host and port if defined. 
+  # There is no unix socket path by default. 
+  config :path, :validate => :string
+
   # The Redis database number.
   config :db, :validate => :number, :default => 0
 
@@ -68,7 +72,7 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
   end
 
   def register
-    @redis_url = "redis://#{@password}@#{@host}:#{@port}/#{@db}"
+    @redis_url = @path.nil? ? "redis://#{@password}@#{@host}:#{@port}/#{@db}" : "#{@password}@#{@path}/#{@db}"
 
     @redis_builder ||= method(:internal_redis_builder)
 
@@ -114,13 +118,24 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
 
   # private
   def redis_params
-    {
-      :host => @host,
-      :port => @port,
+    if @path.nil? 
+      connectionParams = {
+        :host => @host,
+        :port => @port
+      }
+    else
+      connectionParams = {
+        :path => @path
+      }
+    end
+
+    baseParams = {
       :timeout => @timeout,
       :db => @db,
       :password => @password.nil? ? nil : @password.value
     }
+
+    return connectionParams.merge(baseParams)
   end
 
   # private


### PR DESCRIPTION
Adds support for unix sockets on connecting to redis. Can result in a 50% increase in performance (https://redis.io/topics/benchmarks) and provides a touch of local ACL’s (permissions on the local file descriptor).

We use Redis heavily at Speedtest.net as a local pre-buffer for logstash, and using unix sockets helps reduce the local overhead. 
 
Corresponding `logstash-output-redis` PR: https://github.com/logstash-plugins/logstash-output-redis/pull/57