### PR TITLE
Fix broken asciidoc ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.1
+  - Docs: Fix broken asciidoc ID
+
 ## 3.2.0
   - Add support for SSL #61
   - Add support for Redis unix sockets #64

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -94,7 +94,7 @@ The Redis database number.
 
 The hostname of your Redis server.
 
-id="plugins-{type}s-{plugin}-path"]
+[id="plugins-{type}s-{plugin}-path"]
 ===== `path`
 
   * Value type is <<string,string>>

--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-redis'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Redis instance"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This asciidoc error will break the doc build. I've fixed it manually in the versioned plugin reference. 

@ph This plugin will need to be published before you generate the docs again. 