### PR TITLE
Update redis as logstash redis output now uses 4

### DIFF
--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'redis', '~> 3'
+  s.add_runtime_dependency 'redis', '~> 4'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
