### PR TITLE
List pattern support

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -84,12 +84,14 @@ Redis allows for the renaming or disabling of commands in its protocol, see:  ht
 ===== `data_type`
 
   * This is a required setting.
-  * Value can be any of: `list`, `channel`, `pattern_channel`
+  * Value can be any of: `list`, `pattern_list`, `channel`, `pattern_channel`
   * There is no default value for this setting.
 
 Specify either list or channel.  If `data_type` is `list`, then we will BLPOP the
-key.  If `data_type` is `channel`, then we will SUBSCRIBE to the key.
-If `data_type` is `pattern_channel`, then we will PSUBSCRIBE to the key.
+key. If `data_type` is `pattern_list`, then we will spawn a number of worker
+threads that will LPOP from keys matching that pattern.  If `data_type` is
+`channel`, then we will SUBSCRIBE to the key. If `data_type` is
+`pattern_channel`, then we will PSUBSCRIBE to the key.
 
 [id="plugins-{type}s-{plugin}-db"]
 ===== `db`
@@ -125,6 +127,7 @@ The unix socket path of your Redis server.
 
 The name of a Redis list or channel.
 
+
 [id="plugins-{type}s-{plugin}-password"]
 ===== `password`
 
@@ -132,6 +135,37 @@ The name of a Redis list or channel.
   * There is no default value for this setting.
 
 Password to authenticate with. There is no authentication by default.
+
+
+[id="plugins-{type}s-{plugin}-pattern_list_max_items"]
+===== `pattern_list_max_items`
+
+  * Value type is <<number,number>>
+  * Default value is `1000`
+
+Maximum number of items for a single worker thread to process when `data_type` is `pattern_list`.
+After the list is empty or this number of items have been processed, the thread will exit and a
+new one will be started if there are non-empty lists matching the pattern without a consumer.
+
+
+[id="plugins-{type}s-{plugin}-pattern_list_threadpool_sleep"]
+===== `pattern_list_threadpool_sleep`
+
+  * Value type is <<number,number>>
+  * Default value is `0.2`
+
+Time to sleep in main loop after checking if more threads can/need to be spawned.
+Applies to `data_type` is `pattern_list`
+
+
+[id="plugins-{type}s-{plugin}-pattern_list_threads"]
+===== `pattern_list_threads`
+
+  * Value type is <<number,number>>
+  * Default value is `20`
+
+Maximum number of worker threads to spawn when using `data_type` `pattern_list`.
+
 
 [id="plugins-{type}s-{plugin}-port"]
 ===== `port`
@@ -141,8 +175,9 @@ Password to authenticate with. There is no authentication by default.
 
 The port to connect on.
 
+
 [id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl` 
+===== `ssl`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -157,7 +192,6 @@ Enable SSL support.
   * Default value is `1`
 
 
-
 [id="plugins-{type}s-{plugin}-timeout"]
 ===== `timeout`
 
@@ -165,6 +199,8 @@ Enable SSL support.
   * Default value is `5`
 
 Initial connection timeout in seconds.
+
+
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/plugin_mixins/redis_connection.rb
+++ b/lib/logstash/plugin_mixins/redis_connection.rb
@@ -1,0 +1,134 @@
+# encoding: utf-8
+require "logstash/namespace"
+
+module LogStash module PluginMixins module RedisConnection
+  def self.included(base)
+    base.extend(self)
+    base.setup_redis_connection_config
+  end
+
+  public
+
+  def setup_redis_connection_config
+    # The hostname of your Redis server.
+    config :host, :validate => :string, :default => "127.0.0.1"
+
+    # The port to connect on.
+    config :port, :validate => :number, :default => 6379
+
+    # SSL
+    config :ssl, :validate => :boolean, :default => false
+
+    # The unix socket path to connect on. Will override host and port if defined.
+    # There is no unix socket path by default.
+    config :path, :validate => :string
+
+    # The Redis database number.
+    config :db, :validate => :number, :default => 0
+
+    # Initial connection timeout in seconds.
+    config :timeout, :validate => :number, :default => 5
+
+    # Password to authenticate with. There is no authentication by default.
+    config :password, :validate => :password
+
+    # Redefined Redis commands to be passed to the Redis client.
+    config :command_map, :validate => :hash, :default => {}
+  end
+
+  # public API
+  # use to store a proc that can provide a Redis instance or mock
+  def add_external_redis_builder(builder) #callable
+    @redis_builder = builder
+    self
+  end
+
+  # use to apply an instance directly and bypass the builder
+  def use_redis(instance)
+    @redis = instance
+    self
+  end
+
+  def new_redis_instance
+    @redis_builder.call
+  end
+
+  private
+
+  # private
+  def redis_params
+    if @path.nil?
+      connection_params = {
+          :host => @host,
+          :port => @port
+      }
+    else
+      @logger.warn("Parameter 'path' is set, ignoring parameters: 'host' and 'port'")
+      connection_params = {
+          :path => @path
+      }
+    end
+
+    base_params = {
+        :timeout => @timeout,
+        :db => @db,
+        :password => @password.nil? ? nil : @password.value,
+        :ssl => @ssl
+    }
+
+    connection_params.merge(base_params)
+  end
+
+  # private
+  def internal_redis_builder
+    ::Redis.new(redis_params)
+  end
+
+  # private
+  def reset_redis
+    return if @redis.nil? || !@redis.connected?
+
+    @redis.quit rescue nil
+    @redis = nil
+  end
+
+  # private
+  def connect(batch=false)
+    redis = new_redis_instance
+    # register any renamed Redis commands
+    if @command_map.any?
+      client_command_map = redis.client.command_map
+      @command_map.each do |name, renamed|
+        client_command_map[name.to_sym] = renamed.to_sym
+      end
+    end
+    load_batch_script(redis) if batch
+    redis
+  end
+
+  # private
+  def load_batch_script(redis)
+    #A Redis Lua EVAL script to fetch a count of keys
+    redis_script = <<EOF
+  local batchsize = tonumber(ARGV[1])
+  local result = redis.call(\'#{@command_map.fetch('lrange', 'lrange')}\', KEYS[1], 0, batchsize)
+  redis.call(\'#{@command_map.fetch('ltrim', 'ltrim')}\', KEYS[1], batchsize + 1, -1)
+  return result
+EOF
+    @redis_script_sha = redis.script(:load, redis_script)
+  end
+
+  # private
+  def redis_runner(batched=false)
+    begin
+      @redis ||= connect(batched)
+      yield
+    rescue ::Redis::BaseError => e
+      @logger.warn("Redis connection problem", :exception => e)
+      # Reset the redis variable to trigger reconnect
+      @redis = nil
+      Stud.stoppable_sleep(1) { stop? }
+      retry unless stop?
+    end
+  end
+end end end # RedisConnection PluginMixins LogStash


### PR DESCRIPTION
Add support for reading from list patterns such as `logstash.*`. Related issue: https://github.com/logstash-plugins/logstash-input-redis/issues/49

The motivation in our case is that we want to be able to see and control when individual applications produce spammy logs for whatever reason. In those situations, it's also important to be able to guarantee some level of fairness when consuming the queues, as opposed to having just one queue dominated by a potentially misbehaving application.

The implementation supports consuming single items per list using `LPOP`, as well as batched consuming using the same `EVAL` based logic as the regular `list` `data_type` input.

The logic is based on using a configurable-size [concurrent-ruby thread pool](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/docs-source/thread_pools.md). The main loop keeps polling the key pattern using the `KEYS` command and whenever the thread pool queue isn't full, posts a new job to the thread pool for consuming a single key. It keeps track of the keys currently queued and makes sure there's only one job per key at a time.

I also did some refactoring and wanted to do more but decided to make this PR before going further in order to get some opinions. So far I extracted the Redis connection logic as a MixIn - it's all in a single commit and can be reverted if need be. What I'd like to do is make all the 3 different use cases (list, pattern list, PubSub) independent classes implementing an interface. It's currently quite messy with so much unrelated code in a single class.

I'm not a Ruby developer (although I did gather input from colleagues who are) so let me know if there's anything silly, or if this somehow violates any logstash/elastic practices :)