### PR TITLE
remove ruby pipeline dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.1
+  - Remove ruby pipeline dependency. Starting from Logstash 8, Ruby execution engine is not available. All pipelines should use Java pipeline [#84](https://github.com/logstash-plugins/logstash-input-redis/pull/84)
+
 ## 3.5.1
   - [DOC] Reordered config option to alpha order [#79](https://github.com/logstash-plugins/logstash-input-redis/issues/79)
 

--- a/batch_perf/perf_batch.rb
+++ b/batch_perf/perf_batch.rb
@@ -3,7 +3,7 @@ require "redis"
 require "securerandom"
 
 require "logstash/event"
-require "logstash/pipeline"
+require "logstash/java_pipeline"
 require_relative "../lib/logstash/inputs/redis"
 
 class BenchOptions
@@ -35,7 +35,7 @@ end
 bench_options = BenchOptions.new
 
 def input(cfg, slow, &block)
-  pipeline = LogStash::Pipeline.new(cfg)
+  pipeline = LogStash::JavaPipeline.new(cfg)
   queue = Queue.new
 
   pipeline.instance_eval do

--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-redis'
-  s.version         = '3.5.1'
+  s.version         = '3.6.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Redis instance"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Fixed: https://github.com/elastic/logstash/issues/11236

This PR replace ruby pipeline with java pipeline