### PR TITLE
Fix: resolve crash when commands_map is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.1
+  - Fix: resolve crash when commands_map is set [#86](https://github.com/logstash-plugins/logstash-input-redis/pull/86)
+
 ## 3.6.0
   - Remove ruby pipeline dependency. Starting from Logstash 8, Ruby execution engine is not available. All pipelines should use Java pipeline [#84](https://github.com/logstash-plugins/logstash-input-redis/pull/84)
 

--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -157,11 +157,8 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
     redis = new_redis_instance
 
     # register any renamed Redis commands
-    if @command_map.any?
-      client_command_map = redis.client.command_map
-      @command_map.each do |name, renamed|
-        client_command_map[name.to_sym] = renamed.to_sym
-      end
+    @command_map.each do |name, renamed|
+      redis._client.command_map[name.to_sym] = renamed.to_sym
     end
 
     load_batch_script(redis) if batched? && is_list_type?
@@ -270,14 +267,14 @@ EOF
     return if @redis.nil? || !@redis.connected?
     # if its a SubscribedClient then:
     # it does not have a disconnect method (yet)
-    if @redis.client.is_a?(::Redis::SubscribedClient)
+    if @redis.subscribed?
       if @data_type == 'pattern_channel'
-        @redis.client.punsubscribe
+        @redis.punsubscribe
       else
-        @redis.client.unsubscribe
+        @redis.unsubscribe
       end
     else
-      @redis.client.disconnect
+      @redis.disconnect!
     end
     @redis = nil
   end

--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
-  s.add_runtime_dependency 'redis', '~> 4'
+  s.add_runtime_dependency 'redis', '>= 4.0.1', '< 5'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-redis'
-  s.version         = '3.6.0'
+  s.version         = '3.6.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Redis instance"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -166,10 +166,14 @@ describe LogStash::Inputs::Redis do
         expect(command[2]).to eql 1
       end.and_return ['foo', "{\"foo1\":\"bar\""], nil
 
-      thread = Thread.new do
-        subject.run(queue)
+      tt = Thread.new do
+        sleep 0.25
+        subject.do_stop
       end
-      thread.join(1.0)
+
+      subject.run(queue)
+
+      tt.join
 
       expect( queue.size ).to be > 0
     end
@@ -183,10 +187,14 @@ describe LogStash::Inputs::Redis do
           expect(command[0]).to eql :evalsha
         end.and_return ['{"a": 1}', '{"b":'], []
 
-        thread = Thread.new do
-          subject.run(queue)
+        tt = Thread.new do
+          sleep 0.25
+          subject.do_stop
         end
-        thread.join(1.0)
+
+        subject.run(queue)
+
+        tt.join
 
         expect( queue.size ).to be > 0
       end
@@ -204,7 +212,7 @@ describe LogStash::Inputs::Redis do
         end.and_return []
 
         tt = Thread.new do
-          sleep 1
+          sleep 0.25
           subject.do_stop
         end
 

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -365,14 +365,6 @@ describe LogStash::Inputs::Redis do
 
   context "when using data type" do
 
-    # before do
-    #   allow_any_instance_of( Redis ).to receive(:evalsha).and_return []
-    #   allow_any_instance_of( Redis ).to receive(:script)
-    #   allow_any_instance_of( Redis ).to receive(:psubscribe)
-    #   allow_any_instance_of( Redis ).to receive(:subscribe)
-    #   allow_any_instance_of( Redis ).to receive(:quit)
-    # end
-
     ["list", "channel", "pattern_channel"].each do |data_type|
       context data_type do
         it_behaves_like "an interruptible input plugin", :redis => true do


### PR DESCRIPTION
The plugin changes here were not compatible with Redis 4 (due `redis.client` usage).
Likely missed while upgrading from Redis 3.x - probably due mocking the redis interface completely in tests.

Setting `commands_map => ...` for the plugin never really worked (see #80 for details).

The updated interface is based on `Redis` [4.0.1](https://github.com/redis/redis-rb/blob/v4.0.1/lib/redis.rb).

Specs look a bit ugly but should be less "mocky" than before, they will likely need more :baby_bottle:.

resolves https://github.com/logstash-plugins/logstash-input-redis/issues/80