### PR TITLE
Fix: make sure plugin can be stop-ed

### DIFF
--- a/.ci/docker-compose.override.yml
+++ b/.ci/docker-compose.override.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+services:
+    logstash:
+      network_mode: host

--- a/.ci/docker-compose.override.yml
+++ b/.ci/docker-compose.override.yml
@@ -1,7 +1,0 @@
-version: '3'
-
-services:
-
-  logstash:
-    ports: # gain access to Redis
-      - "6379:6379"

--- a/.ci/docker-compose.override.yml
+++ b/.ci/docker-compose.override.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+services:
+
+  logstash:
+    ports: # gain access to Redis
+      - "6379:6379"

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This is intended to be run inside the docker container as the command of the docker-compose.
+
+env
+
+set -ex
+
+jruby -rbundler/setup -S rspec -fd
+
+jruby -rbundler/setup -S rspec -fd --tag redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ import:
 
 services:
   - redis-server
+
+before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
+  - sudo service redis-server stop
+  - sudo service redis-server start --bind 127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ import:
 - logstash-plugins/.ci:travis/travis.yml@1.x
 
 services:
-  - redis-server
+  - redis
 
-before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
-  - sudo service redis-server stop || true
-  - sudo service redis-server start --bind 127.0.0.1
+#before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
+#  - sudo service redis-server stop || true
+#  - sudo service redis-server start --bind 127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 import:
 - logstash-plugins/.ci:travis/travis.yml@1.x
 
-services:
-  - redis
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:chris-lea/redis-server'
+    packages:
+      - redis-server
 
 #before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
 #  - sudo service redis-server stop || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
     packages:
       - redis-server
 
-#before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
-#  - sudo service redis-server stop
-#  - sudo service redis-server start --bind 127.0.0.1
+before_install:
+  - sudo service redis-server stop
+  - sudo service redis-server start --bind 0.0.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
     packages:
       - redis-server
 
-before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
-  - sudo service redis-server stop
-  - sudo service redis-server start --bind 127.0.0.1
+#before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
+#  - sudo service redis-server stop
+#  - sudo service redis-server start --bind 127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 import:
 - logstash-plugins/.ci:travis/travis.yml@1.x
+
+services:
+  - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
     packages:
       - redis-server
 
-#before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
-#  - sudo service redis-server stop || true
-#  - sudo service redis-server start --bind 127.0.0.1
+before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
+  - sudo service redis-server stop
+  - sudo service redis-server start --bind 127.0.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ services:
   - redis-server
 
 before_install: # Redis tried to bind to ::1 but IPv6 isn't supported
-  - sudo service redis-server stop
+  - sudo service redis-server stop || true
   - sudo service redis-server start --bind 127.0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.0
+  - Fix: make sure plugin can be stop-ed in case of a channel data_type [#87](https://github.com/logstash-plugins/logstash-input-redis/pull/87)
+  - Test: start running integration specs on CI
+
 ## 3.6.1
   - Fix: resolve crash when commands_map is set [#86](https://github.com/logstash-plugins/logstash-input-redis/pull/86)
 

--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -107,26 +107,22 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
 
   # private
   def redis_params
-    if @path.nil?
-      connectionParams = {
-        :host => @host,
-        :port => @port
-      }
-    else
-      @logger.warn("Parameter 'path' is set, ignoring parameters: 'host' and 'port'")
-      connectionParams = {
-        :path => @path
-      }
-    end
-
-    baseParams = {
-      :timeout => @timeout,
-      :db => @db,
-      :password => @password.nil? ? nil : @password.value,
-      :ssl => @ssl
+    params = {
+        :timeout => @timeout,
+        :db => @db,
+        :password => @password.nil? ? nil : @password.value,
+        :ssl => @ssl
     }
 
-    return connectionParams.merge(baseParams)
+    if @path.nil?
+      params[:host] = @host
+      params[:port] = @port
+    else
+      @logger.warn("Parameter 'path' is set, ignoring parameters: 'host' and 'port'")
+      params[:path] = @path
+    end
+
+    params
   end
 
   TIMEOUT = 5 # Redis only supports Integer values

--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -126,7 +126,6 @@ module LogStash module Inputs class Redis < LogStash::Inputs::Threadable
   end
 
   TIMEOUT = 5 # Redis only supports Integer values
-  private_constant :TIMEOUT
 
   def new_redis_instance
     ::Redis.new(redis_params)

--- a/lib/logstash/inputs/redis.rb
+++ b/lib/logstash/inputs/redis.rb
@@ -281,6 +281,9 @@ EOF
       @logger.warn("Redis connection error", info)
     when ::Redis::BaseError
       @logger.error("Redis error", info)
+    when ::LogStash::ShutdownSignal
+      @logger.debug("Received shutdown signal")
+      return false # stop retry-ing
     else
       info[:backtrace] ||= e.backtrace
       @logger.error("Unexpected error", info)

--- a/logstash-input-redis.gemspec
+++ b/logstash-input-redis.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-redis'
-  s.version         = '3.6.1'
+  s.version         = '3.7.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from a Redis instance"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -375,6 +375,10 @@ describe LogStash::Inputs::Redis do
 
     ["list", "channel", "pattern_channel"].each do |data_type|
       context data_type do
+        # TODO pending
+        # redis-rb ends up in a read wait loop since we do not use subscribe_with_timeout
+        next unless data_type == 'list'
+
         it_behaves_like "an interruptible input plugin", :redis => true do
           let(:config) { { 'key' => 'foo', 'data_type' => data_type } }
         end

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -375,10 +375,6 @@ describe LogStash::Inputs::Redis do
 
     ["list", "channel", "pattern_channel"].each do |data_type|
       context data_type do
-        # TODO pending
-        # redis-rb ends up in a read wait loop since we do not use subscribe_with_timeout
-        next unless data_type == 'list'
-
         it_behaves_like "an interruptible input plugin", :redis => true do
           let(:config) { { 'key' => 'foo', 'data_type' => data_type } }
         end

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -166,7 +166,6 @@ describe LogStash::Inputs::Redis do
       allow_any_instance_of( Redis::Client ).to receive(:call_with_timeout) do |_, command, timeout, &block|
         expect(command[0]).to eql :blpop
         expect(command[1]).to eql ['foo', 0]
-        expect(command[2]).to eql 1
       end.and_return ['foo', "{\"foo1\":\"bar\""], nil
 
       tt = Thread.new do


### PR DESCRIPTION
Currently not all specs from the suite are run, as some are tagged with `redis`.
These require a real Redis server, no reason not to run them against CI as well.

While getting CI to run the rest of the suite I realized the plugin isn't always interruptible.
In case of `data_type => channel` and `data_type => pattern_channel` the Redis API used is blocking (simply waits forever until more data comes in) thus the change to use an alternative "timeout" APIs with these.