### PR TITLE
Resolve hanging tests

### DIFF
--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -166,7 +166,7 @@ describe LogStash::Inputs::Redis do
       allow_any_instance_of( Redis::Client ).to receive(:call_with_timeout) do |_, command, timeout, &block|
         expect(command[0]).to eql :blpop
         expect(command[1]).to eql ['foo', 0]
-      end.and_return ['foo', "{\"foo1\":\"bar\""], nil
+      end.and_return ['foo', "{\"foo1\":\"bar\"}"], nil
 
       tt = Thread.new do
         sleep 0.25

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -351,7 +351,7 @@ describe LogStash::Inputs::Redis do
         return false if Time.now > end_time
         sleep(0.1)
       end
-      return true
+      true
     end
 
     def channel_ready?(timeout = 2)
@@ -361,7 +361,7 @@ describe LogStash::Inputs::Redis do
         return false if Time.now > end_time
         sleep(0.1)
       end
-      return true
+      true
     end
 
     before(:example, type: :mocked) do

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -250,7 +250,7 @@ describe LogStash::Inputs::Redis do
         allow_any_instance_of( Redis ).to receive(:script)
         allow_any_instance_of( Redis::Client ).to receive(:call) do |_, command|
           expect(command[0]).to eql :evalsha
-        end.and_return ['{"a": 1}', '{"b":'], []
+        end.and_return ['{"a": 1}', '{"b": 2}'], []
 
         tt = Thread.new do
           sleep 0.25

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -368,6 +368,7 @@ describe LogStash::Inputs::Redis do
         it 'calling the run method, adds events to the queue' do
           #simulate the input thread
           rt = run_it_thread(subject)
+          sleep(2)
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'c').join
           #simulate the pipeline thread
@@ -378,6 +379,7 @@ describe LogStash::Inputs::Redis do
         it 'events had redis_channel' do
           #simulate the input thread
           rt = run_it_thread(subject)
+          sleep(2)
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'c').join
           #simulate the pipeline thread
@@ -406,6 +408,7 @@ describe LogStash::Inputs::Redis do
         it 'calling the run method, adds events to the queue' do
           #simulate the input thread
           rt = run_it_thread(subject)
+          sleep(2)
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'pc').join
           #simulate the pipeline thread
@@ -417,6 +420,7 @@ describe LogStash::Inputs::Redis do
         it 'events had redis_channel' do
           #simulate the input thread
           rt = run_it_thread(subject)
+          sleep(2)
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'pc').join
           #simulate the pipeline thread

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -324,7 +324,7 @@ describe LogStash::Inputs::Redis do
       Thread.new(new_redis, prefix) do |r, p|
         sleep 0.1
         2.times do |i|
-          r.publish('foo', "#{p}#{i.next}")
+          r.publish('foo', { data: "#{p}#{i.next}" }.to_json)
         end
       end
     end

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -368,7 +368,7 @@ describe LogStash::Inputs::Redis do
         it 'calling the run method, adds events to the queue' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(1) # Give the subscribe request a chance to complete
+          sleep(0.5) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'c').join
           #simulate the pipeline thread
@@ -379,7 +379,7 @@ describe LogStash::Inputs::Redis do
         it 'events had redis_channel' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(1) # Give the subscribe request a chance to complete
+          sleep(0.5) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'c').join
           #simulate the pipeline thread
@@ -408,7 +408,7 @@ describe LogStash::Inputs::Redis do
         it 'calling the run method, adds events to the queue' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(1) # Give the subscribe request a chance to complete
+          sleep(0.5) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'pc').join
           #simulate the pipeline thread
@@ -420,7 +420,7 @@ describe LogStash::Inputs::Redis do
         it 'events had redis_channel' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(1) # Give the subscribe request a chance to complete
+          sleep(0.5) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'pc').join
           #simulate the pipeline thread

--- a/spec/inputs/redis_spec.rb
+++ b/spec/inputs/redis_spec.rb
@@ -368,7 +368,7 @@ describe LogStash::Inputs::Redis do
         it 'calling the run method, adds events to the queue' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(2)
+          sleep(1) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'c').join
           #simulate the pipeline thread
@@ -379,7 +379,7 @@ describe LogStash::Inputs::Redis do
         it 'events had redis_channel' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(2)
+          sleep(1) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'c').join
           #simulate the pipeline thread
@@ -408,7 +408,7 @@ describe LogStash::Inputs::Redis do
         it 'calling the run method, adds events to the queue' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(2)
+          sleep(1) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'pc').join
           #simulate the pipeline thread
@@ -420,7 +420,7 @@ describe LogStash::Inputs::Redis do
         it 'events had redis_channel' do
           #simulate the input thread
           rt = run_it_thread(subject)
-          sleep(2)
+          sleep(1) # Give the subscribe request a chance to complete
           #simulate the other system thread
           publish_thread(subject.send(:new_redis_instance), 'pc').join
           #simulate the pipeline thread


### PR DESCRIPTION
This PR adds a method that checks to make sure channels are created before they are published to in the tests.

The tests were hanging because there was a race condition:
- The tests sometimes attempted to publish an event before the subscribe request was complete and a channel was created
- The first event therefore wasn't enqueued
- Then, the test tried to pop events from the queue and the first event popped was actually the second event ('c2' or 'p2')
- Then the test tried to pop a second event and would block waiting indefinitely, but there was no second event, as the first was never enqueued.

The new method checks in a loop with a timeout that a channel exists so that events can be successfully published.

Here are some print statements from debugging that show that the first event popped from the queue is actually the second event:
```
w Enable Watchlogstash-1  | channel: starting run thread with queue: 4096, queue.size: 0
w Enable Watchlogstash-1  | starting publish thread queue: 4096, queue.size: 0
w Enable Watchlogstash-1  | popping first event
w Enable Watchlogstash-1  | popped message {"c":"2"}
w Enable Watchlogstash-1  | popping second event
```

Additionally, I found that if the event was attempted to be published and enqueued before the subscription had completed, the redis client would return a 0 from the publish method call. It should return 1 if the event was successfully published. 

```
sending event c1
@client.call command [:publish, "foo", "{\"data\":\"c1\"}"]: #<Method: Redis::Client#call(command) .../.rvm/gems/jruby-9.4.13.0/gems/redis-4.8.1/lib/redis/client.rb:160>
reply: 0
sending c2
@client.call command [:publish, "foo", "{\"data\":\"c2\"}"]: #<Method: Redis::Client#call(command) .../.rvm/gems/jruby-9.4.13.0/gems/redis-4.8.1/lib/redis/client.rb:160>
reply: 1
```

I've also updated the data that is published to be a json object, as there were intermittent errors:
```
[2025-10-28T08:54:44,076][ERROR][logstash.codecs.json     ] JSON parse error, original data now in message field {:message=>"Unrecognized token 'pc1': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')\n at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 4]", :exception=>LogStash::Json::ParserError, :data=>"pc1"}
```

Resolves #97 